### PR TITLE
#2 - resolved using named volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     restart: always
     volumes:
       - ./tracker_api:/tracker
+      - api-packages:/tracker/node_modules
     depends_on:
       - db
 
@@ -39,6 +40,7 @@ services:
     restart: always
     volumes:
       - ./tracker_webui:/tracker
+      - webui-packages:/tracker/node_modules
     depends_on:
       - api
 
@@ -51,3 +53,10 @@ services:
       - ./nginx:/etc/nginx/conf.d
     depends_on:
       - webui
+
+volumes:
+  api-packages:
+    name: api-packages
+  webui-packages:
+    name: webui-packages
+


### PR DESCRIPTION
#2 - i resolved this issue using named volumes, as we dont have any node_modules after mounting, the machine is unable to find the `tsc` properly, so better creating a volume out of node_modules will solve the issue.

Working Containers

![image](https://user-images.githubusercontent.com/66376642/236672761-c70d75c9-aaf2-4bc2-9884-87d32bc39470.png)
