### PR TITLE
#9 serve and expose port mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   webui:
     build: ./tracker_webui
-    command: bash -c "npm run build && serve dist"
+    command: bash -c "npm run build && serve dist -p 8080"
     container_name: "Tracker-Frontend"
     environment:
       NODE_ENV: ${NODE_ENV:-local}


### PR DESCRIPTION
#9 - added port flag with `8080` port to launch `tracker:webui` in correct port number